### PR TITLE
Pin PyYAML version and fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/knowit/properties/duration.py
+++ b/knowit/properties/duration.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import re
-
 from datetime import timedelta
 from six import text_type
 

--- a/knowit/providers/mediainfo.py
+++ b/knowit/providers/mediainfo.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import locale
 import os
 import sys
-
 from ctypes import c_size_t, c_void_p, c_wchar_p
 from logging import NullHandler, getLogger
 from subprocess import check_output

--- a/knowit/rules/language.py
+++ b/knowit/rules/language.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import re
-
 from logging import NullHandler, getLogger
 import babelfish
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ install_requirements = ['babelfish>=0.5.2', 'enzyme>=0.4.1', 'pint>=0.8', 'pymed
                         'six>=1.9.0']
 test_requirements = ['flake8_docstrings', 'flake8-import-order', 'pydocstyle',
                      'pep8-naming', 'pytest>=2.8', 'pytest-cov', 'pytest-flake8']
+# Remove the following line when `flake8` supports `pycodestyle` >= 2.4.0
+#   See https://gitlab.com/pycqa/flake8/issues/415
+test_requirements.append('pycodestyle<2.4.0')
 
 if sys.version_info < (3, 3):
     test_requirements.append('mock')

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def find_version(*file_paths):
 
 
 setup_requirements = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection(sys.argv) else []
-install_requirements = ['babelfish>=0.5.2', 'enzyme>=0.4.1', 'pint>=0.8', 'pymediainfo>=2.1.5', 'PyYAML',
+install_requirements = ['babelfish>=0.5.2', 'enzyme>=0.4.1', 'pint>=0.8', 'pymediainfo>=2.1.5', 'PyYAML<4',
                         'six>=1.9.0']
 test_requirements = ['flake8_docstrings', 'flake8-import-order', 'pydocstyle',
                      'pep8-naming', 'pytest>=2.8', 'pytest-cov', 'pytest-flake8']

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,10 +3,8 @@ from __future__ import print_function, unicode_literals
 
 import re
 import sys
-
 from collections import Mapping
 from datetime import timedelta
-
 from pkg_resources import resource_exists, resource_isdir, resource_listdir, resource_stream
 from six import string_types
 import yaml
@@ -17,7 +15,7 @@ from knowit.units import units
 
 try:
     from mock import Mock
-except:
+except ImportError:
     from unittest.mock import Mock
 
 


### PR DESCRIPTION
PyYAML released a new major version but reverted it after a day or so.
Still, it's a good idea to pin PyYAML to version `<4`, because [they are planning to release 4.2 soon™](https://github.com/yaml/pyyaml/issues/193).

Tests were failing for me because flake8 is incompatible with pycodestyle >= 2.4.0, so I pinned the latter to the previous minor version.

Plus some needed lint fixes and a missing `.gitignore` line.

@ratoaq2 