### PR TITLE
Add Python 3.7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
+  - 3.9
 
 env:
   - PARSER=native

--- a/knowit/__init__.py
+++ b/knowit/__init__.py
@@ -24,4 +24,4 @@ try:
 except ImportError:  # pragma: no cover
     from ordereddict import OrderedDict
 
-from .api import know
+from .api import KnowitException, know

--- a/knowit/__main__.py
+++ b/knowit/__main__.py
@@ -39,33 +39,29 @@ def build_argument_parser():
     opts.add_argument(dest='videopath', help='Path to the video to introspect', nargs='*')
 
     provider_opts = opts.add_argument_group('Providers')
-    provider_opts.add_argument('-p', '--provider', dest='provider', default=None,
+    provider_opts.add_argument('-p', '--provider', dest='provider',
                                help='The provider to be used: mediainfo, ffmpeg or enzyme.')
 
-    input_opts = opts.add_argument_group('Input')
-    input_opts.add_argument('-E', '--fail-on-error', action='store_true', dest='fail_on_error', default=True,
-                            help='Fail when errors are found on the media file.')
-
     output_opts = opts.add_argument_group('Output')
-    output_opts.add_argument('--debug', action='store_true', dest='debug', default=False,
+    output_opts.add_argument('--debug', action='store_true', dest='debug',
                              help='Print useful information for debugging knowit and for reporting bugs.')
-    output_opts.add_argument('--report', action='store_true', dest='report', default=False,
+    output_opts.add_argument('--report', action='store_true', dest='report',
                              help='Parse media and report all non-detected values')
-    output_opts.add_argument('-y', '--yaml', action='store_true', dest='yaml', default=False,
+    output_opts.add_argument('-y', '--yaml', action='store_true', dest='yaml',
                              help='Display output in yaml format')
-    output_opts.add_argument('-N', '--no-units', action='store_true', dest='no_units', default=False,
+    output_opts.add_argument('-N', '--no-units', action='store_true', dest='no_units',
                              help='Display output without units')
-    output_opts.add_argument('-P', '--profile', dest='profile', default='default',
+    output_opts.add_argument('-P', '--profile', dest='profile',
                              help='Display values according to specified profile: code, default, human, technical')
 
     conf_opts = opts.add_argument_group('Configuration')
-    conf_opts.add_argument('--mediainfo', dest='mediainfo', default=None,
+    conf_opts.add_argument('--mediainfo', dest='mediainfo',
                            help='The location to search for MediaInfo binaries')
-    conf_opts.add_argument('--ffmpeg', dest='ffmpeg', default=None,
+    conf_opts.add_argument('--ffmpeg', dest='ffmpeg',
                            help='The location to search for FFmpeg (ffprobe) binaries')
 
     information_opts = opts.add_argument_group('Information')
-    information_opts.add_argument('--version', dest='version', action='store_true', default=False,
+    information_opts.add_argument('--version', dest='version', action='store_true',
                                   help='Display knowit version.')
 
     return opts
@@ -131,6 +127,8 @@ def main(args=None):
                 logger.exception('OS error when processing video')
             except UnicodeError:
                 logger.exception('Character encoding error when processing video')
+            except api.KnowitException as e:
+                logger.error(e)
             if options.report and i % 20 == 19 and report:
                 console.info('Unknown values so far:')
                 console.info(dump(report, options, vars(options)))
@@ -144,31 +142,9 @@ def main(args=None):
                 console.info('Knowit %s knows everything. :-)', __version__)
 
     elif options.version:
-        console.info('+-------------------------------------------------------+')
-        _print_centered('KnowIt {0}'.format(__version__))
-        console.info('+-------------------------------------------------------+')
-
-        first = True
-        for key, info in api.dependencies(vars(options)).items():
-            if not first:
-                _print_centered('')
-            first = False
-
-            for k, v in info.items():
-                _print_centered(k)
-                _print_centered(v)
-
-        console.info('+-------------------------------------------------------+')
-        console.info('|      Please report any bug or feature request at      |')
-        console.info('|     https://github.com/ratoaq2/knowit/issues.         |')
-        console.info('+-------------------------------------------------------+')
+        console.info(api.debug_info())
     else:
         argument_parser.print_help()
-
-
-def _print_centered(value):
-    value = value[-52:]
-    console.info('| {msg:^53} |'.format(msg=value))
 
 
 if __name__ == '__main__':

--- a/knowit/api.py
+++ b/knowit/api.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from . import OrderedDict
+import traceback
+
+from . import OrderedDict, __version__
 from .config import Config
 from .providers import (
     EnzymeProvider,
@@ -18,6 +20,10 @@ _provider_map = OrderedDict([
 provider_names = _provider_map.keys()
 
 available_providers = OrderedDict([])
+
+
+class KnowitException(Exception):
+    """Exception raised when knowit fails to perform media info extraction because of an internal error."""
 
 
 def initialize(context=None):
@@ -44,30 +50,83 @@ def know(video_path, context=None):
         video_path = video_path.__fspath__()
     except AttributeError:
         pass
-    context = context or {}
-    context.setdefault('profile', 'default')
-    initialize(context)
 
-    for name, provider in available_providers.items():
-        if name != (context.get('provider') or name):
-            continue
+    try:
+        context = context or {}
+        context.setdefault('profile', 'default')
+        initialize(context)
 
-        if provider.accepts(video_path):
-            result = provider.describe(video_path, context)
-            if result:
-                return result
+        for name, provider in available_providers.items():
+            if name != (context.get('provider') or name):
+                continue
 
-    return {}
+            if provider.accepts(video_path):
+                result = provider.describe(video_path, context)
+                if result:
+                    return result
+
+        return {}
+    except Exception:
+        raise KnowitException(debug_info(context=context, exc_info=True))
 
 
 def dependencies(context=None):
     """Return all dependencies detected by knowit."""
-    initialize(context)
     deps = OrderedDict([])
-    for name, provider_cls in _provider_map.items():
-        if name in available_providers:
-            deps[name] = available_providers[name].version
-        else:
-            deps[name] = {}
+    try:
+        initialize(context)
+        for name, provider_cls in _provider_map.items():
+            if name in available_providers:
+                deps[name] = available_providers[name].version
+            else:
+                deps[name] = {}
+    except Exception:
+        pass
 
     return deps
+
+
+def _centered(value):
+    value = value[-52:]
+    return '| {msg:^53} |'.format(msg=value)
+
+
+def debug_info(context=None, exc_info=False):
+    lines = [
+        '+-------------------------------------------------------+',
+        _centered('KnowIt {0}'.format(__version__)),
+        '+-------------------------------------------------------+'
+    ]
+
+    first = True
+    for key, info in dependencies(context).items():
+        if not first:
+            lines.append(_centered(''))
+        first = False
+
+        for k, v in info.items():
+            lines.append(_centered(k))
+            lines.append(_centered(v))
+
+    if context:
+        debug_data = context.pop('debug_data', None)
+
+        lines.append('+-------------------------------------------------------+')
+        for k, v in context.items():
+            if v:
+                lines.append(_centered('{}: {}'.format(k, v)))
+
+        if debug_data:
+            lines.append('+-------------------------------------------------------+')
+            lines.append(debug_data())
+
+    if exc_info:
+        lines.append('+-------------------------------------------------------+')
+        lines.append(traceback.format_exc())
+
+    lines.append('+-------------------------------------------------------+')
+    lines.append(_centered('Please report any bug or feature request at'))
+    lines.append(_centered('https://github.com/ratoaq2/knowit/issues.'))
+    lines.append('+-------------------------------------------------------+')
+
+    return '\n'.join(lines)

--- a/knowit/properties/audio/bitratemode.py
+++ b/knowit/properties/audio/bitratemode.py
@@ -6,5 +6,3 @@ from ...property import Configurable
 
 class BitRateMode(Configurable):
     """Bit Rate mode property."""
-
-    pass

--- a/knowit/properties/audio/compression.py
+++ b/knowit/properties/audio/compression.py
@@ -6,5 +6,3 @@ from ...property import Configurable
 
 class AudioCompression(Configurable):
     """Audio Compression property."""
-
-    pass

--- a/knowit/properties/audio/profile.py
+++ b/knowit/properties/audio/profile.py
@@ -6,5 +6,3 @@ from ...property import Configurable
 
 class AudioProfile(Configurable):
     """Audio profile property."""
-
-    pass

--- a/knowit/properties/video/encoder.py
+++ b/knowit/properties/video/encoder.py
@@ -6,5 +6,3 @@ from ...property import Configurable
 
 class VideoEncoder(Configurable):
     """Video Encoder property."""
-
-    pass

--- a/knowit/properties/video/scantype.py
+++ b/knowit/properties/video/scantype.py
@@ -6,5 +6,3 @@ from ...property import Configurable
 
 class ScanType(Configurable):
     """Scan Type property."""
-
-    pass

--- a/knowit/property.py
+++ b/knowit/property.py
@@ -81,7 +81,7 @@ class Configurable(Property):
     def _lookup(self, key, context):
         result = self.mapping.get(key)
         if result is not None:
-            result = getattr(result, context['profile'])
+            result = getattr(result, context.get('profile') or 'default')
             return result if result != '__ignored__' else False
 
     def handle(self, value, context):

--- a/knowit/providers/ffmpeg.py
+++ b/knowit/providers/ffmpeg.py
@@ -7,7 +7,7 @@ import re
 from logging import NullHandler, getLogger
 from subprocess import check_output
 
-from six import text_type
+from six import ensure_text
 
 from .. import (
     OrderedDict,
@@ -120,15 +120,15 @@ class FFmpegCliExecutor(FFmpegExecutor):
     }
 
     def _execute(self, filename):
-        return check_output([self.location, '-v', 'quiet', '-print_format', 'json',
-                             '-show_format', '-show_streams', '-sexagesimal', filename])
+        return ensure_text(check_output([self.location, '-v', 'quiet', '-print_format', 'json',
+                                         '-show_format', '-show_streams', '-sexagesimal', filename]))
 
     @classmethod
     def create(cls, os_family=None, suggested_path=None):
         """Create the executor instance."""
         for candidate in define_candidate(cls.locations, cls.names, os_family, suggested_path):
             try:
-                output = text_type(check_output([candidate, '-version']))
+                output = ensure_text(check_output([candidate, '-version']))
                 version = cls._get_version(output)
                 if version:
                     logger.debug('FFmpeg cli detected: %s v%s', candidate, '.'.join(map(str, version)))

--- a/knowit/providers/ffmpeg.py
+++ b/knowit/providers/ffmpeg.py
@@ -228,10 +228,16 @@ class FFmpegProvider(Provider):
     def describe(self, video_path, context):
         """Return video metadata."""
         data = self.executor.extract_info(video_path)
+
+        def debug_data():
+            """Debug data."""
+            return json.dumps(data, cls=get_json_encoder(context), indent=4, ensure_ascii=False)
+
+        context['debug_data'] = debug_data
+
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug('Video %r scanned using ffmpeg %r has raw data:\n%s',
-                         video_path, self.executor.location,
-                         json.dumps(data, cls=get_json_encoder(context), indent=4, ensure_ascii=False))
+                         video_path, self.executor.location, debug_data())
 
         general_track = data.get('format') or {}
         if 'tags' in general_track:
@@ -251,9 +257,7 @@ class FFmpegProvider(Provider):
 
         result = self._describe_tracks(video_path, general_track, video_tracks, audio_tracks, subtitle_tracks, context)
         if not result:
-            logger.warning('Invalid file %r', video_path)
-            if context.get('fail_on_error', True):
-                raise MalformedFileError
+            raise MalformedFileError
 
         result['provider'] = self.executor.location
         result['provider'] = {

--- a/knowit/providers/mediainfo.py
+++ b/knowit/providers/mediainfo.py
@@ -149,7 +149,7 @@ class MediaInfoCliExecutor(MediaInfoExecutor):
                     return MediaInfoCliExecutor(candidate, version)
             except CalledProcessError as e:
                 # old mediainfo returns non-zero exit code for mediainfo --version
-                version = cls._get_version(e.output)
+                version = cls._get_version(text_type(e.output))
                 if version:
                     logger.debug('MediaInfo cli detected: %s', candidate)
                     return MediaInfoCliExecutor(candidate, version)

--- a/knowit/providers/mediainfo.py
+++ b/knowit/providers/mediainfo.py
@@ -10,7 +10,7 @@ from xml.etree import ElementTree
 
 from pymediainfo import MediaInfo
 from pymediainfo import __version__ as pymediainfo_version
-from six import text_type
+from six import ensure_text
 
 from .. import (
     OrderedDict,
@@ -131,25 +131,21 @@ class MediaInfoCliExecutor(MediaInfoExecutor):
 
     def _execute(self, filename):
         output_type = 'OLDXML' if self.version >= (17, 10) else 'XML'
-        output = check_output([self.location, '--Output=' + output_type, '--Full', filename])
-        if isinstance(output, bytes):
-            output = output.decode('utf-8')
-
-        return MediaInfo(output)
+        return MediaInfo(ensure_text(check_output([self.location, '--Output=' + output_type, '--Full', filename])))
 
     @classmethod
     def create(cls, os_family=None, suggested_path=None):
         """Create the executor instance."""
         for candidate in define_candidate(cls.locations, cls.names, os_family, suggested_path):
             try:
-                output = text_type(check_output([candidate, '--version']))
+                output = ensure_text(check_output([candidate, '--version']))
                 version = cls._get_version(output)
                 if version:
                     logger.debug('MediaInfo cli detected: %s', candidate)
                     return MediaInfoCliExecutor(candidate, version)
             except CalledProcessError as e:
                 # old mediainfo returns non-zero exit code for mediainfo --version
-                version = cls._get_version(text_type(e.output))
+                version = cls._get_version(ensure_text(e.output))
                 if version:
                     logger.debug('MediaInfo cli detected: %s', candidate)
                     return MediaInfoCliExecutor(candidate, version)

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,15 @@ def find_version(*file_paths):
 
 
 setup_requirements = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection(sys.argv) else []
-install_requirements = ['babelfish>=0.5.5', 'enzyme>=0.4.1', 'pint>=0.9', 'pymediainfo>=3.0', 'PyYAML>=3.13',
-                        'six>=1.12.0']
+install_requirements = [
+    'babelfish>=0.5.5;python_version<"3.10"',
+    'babelfish>0.5.5;python_version>="3.10"',
+    'enzyme>=0.4.1',
+    'pint>=0.9',
+    'pymediainfo>=3.0',
+    'PyYAML>=3.13',
+    'six>=1.12.0',
+]
 test_requirements = ['flake8_docstrings', 'flake8-import-order', 'pydocstyle',
                      'pep8-naming', 'pytest>=4.3.0', 'pytest-cov', 'pytest-flake8', 'requests>=2.21.0']
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Multimedia :: Video'
     ],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@ import json
 import os
 import re
 import sys
-from collections import Mapping
+from collections.abc import Mapping
 from datetime import timedelta
 from zipfile import ZipFile
 

--- a/tests/test_enzyme.py
+++ b/tests/test_enzyme.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import pytest
-from knowit import know
+from knowit import KnowitException, know
 
 from . import (
     assert_expected,
@@ -30,7 +30,11 @@ def test_enzyme_provider_real_media(media, options):
     options['fail_on_error'] = False
 
     # When
-    actual = know(media.video_path, options)
+    if not media.expected_data:
+        with pytest.raises(KnowitException):
+            know(media.video_path, options)
+    else:
+        actual = know(media.video_path, options)
 
-    # Then
-    assert_expected(media.expected_data, actual, options)
+        # Then
+        assert_expected(media.expected_data, actual, options)


### PR DESCRIPTION
This adds Python 3.7+ support without deprecating any end-of-life Python versions.  This should serve as a good point for a final release for Python 2.7 and Python < 3.6.

- Add Python 3.7, 3.8, and 3.9 to tests and classifiers
- Use dict instead of OrderedDict on Python >= 3.6
- [[BPO-36085](https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew)] Generate full path name for DLL on Windows 
- Lint code
