### PR TITLE
Refactor installation and testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ celerybeat-schedule
 .env
 
 # virtualenv
+.venv*/
 venv*/
 ENV/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ before_install:
   - pip install --upgrade pytest
 
 install:
+  - pip install tox-travis
   - pip install -e .
 
-script: python setup.py test --addopts "--verbose $PYTEST_ADDOPTS"
+script:
+  tox
+  tox -e lint
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,3 @@ install:
 
 script:
   tox
-  tox -e lint
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log
 
 before_install:
-  - pip install --upgrade pip, setuptools
+  - pip install --upgrade pip setuptools
   - pip install --upgrade pytest
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log
 
 before_install:
-  - pip install --upgrade pip setuptools
+  - python -m pip install --upgrade pip setuptools
   - pip install --upgrade pytest
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log
 
 before_install:
+  - pip install --upgrade pip, setuptools
   - pip install --upgrade pytest
 
 install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools >= 40.6.0",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,9 @@
 [pytest]
-norecursedirs = venv* .cache .tox .eggs
-addopts = --flake8
+norecursedirs =
+    .cache
+    .eggs
+    .tox
+    .venv*
+    .mypy_cache
+    venv*
 python_files = *test*.py
-flake8-max-line-length = 120
-flake8-ignore =
-    * D100 D103 I201
-    knowit/__init__.py E402 F401
-    knowit/*/__init__.py D104 F401
-    knowit/*/*/__init__.py D104 F401

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,22 @@
-[aliases]
-test=pytest
+[flake8]
+import-order-style = cryptography
+application-import-names = knowit
+max-line-length = 120
+ignore =
+    # D100 Missing docstring in public module
+    D100
+    # D103 Missing docstring in public function
+    D103
+    # I201 Missing newline between import groups
+    I201
+per-file-ignores =
+    __init__.py:
+        # D104 Missing docstring in public package
+        D104
+        # F401 Imported but unused
+        F401
+    knowit/__init__.py:
+        # E402 Module level import not at top of file
+        E402
+        # F401 Imported but unused
+        F401

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 import io
 import os
 import re
-import sys
 
 from setuptools import find_packages, setup
 
@@ -21,7 +20,6 @@ def find_version(*file_paths):
     raise RuntimeError('Unable to find version string.')
 
 
-setup_requirements = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection(sys.argv) else []
 install_requirements = [
     'babelfish>=0.5.5;python_version<"3.10"',
     'babelfish>0.5.5;python_version>="3.10"',
@@ -31,11 +29,6 @@ install_requirements = [
     'PyYAML>=3.13',
     'six>=1.12.0',
 ]
-test_requirements = ['flake8_docstrings', 'flake8-import-order', 'pydocstyle',
-                     'pep8-naming', 'pytest>=4.3.0', 'pytest-cov', 'pytest-flake8', 'requests>=2.21.0']
-
-if sys.version_info < (3, 3):
-    test_requirements.append('mock')
 
 setup(
     name='knowit',
@@ -71,10 +64,5 @@ setup(
     ],
     packages=find_packages(exclude=('tests', 'docs')),
     include_package_data=True,
-    setup_requires=setup_requirements,
     install_requires=install_requirements,
-    tests_require=test_requirements,
-    extras_require={
-        'test': test_requirements,
-    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,35 @@
 [tox]
-envlist = {py27,py33,py34,py35,py36,py37,py38,py39}-{native}
+envlist = py{27,33,34,35,36,37,38,39}-{native}, lint
 
 [testenv]
 commands =
-    python setup.py test --addopts "--cov-report term --cov-report html --cov knowit --verbose {posargs}"
+    python --version
 
-[flake8]
-import-order-style = cryptography
-application-import-names = knowit
+[testenv:py{27,33,34,35,36,37,38,39}-{native}]
+deps =
+    mock ; python_version < "3.3"
+    pytest >= 4.3.0
+    pytest-cov
+    requests >= 2.21.0
+commands =
+    pytest tests --cov-report term --cov-report html --cov knowit --verbose {posargs}
+
+[testenv:lint]
+basepython =
+    python3
+deps =
+    flake8
+    flake8-docstrings
+    flake8-import-order
+    pep8-naming
+    pydocstyle
+commands =
+    flake8 knowit
+
+[testenv:type-check]
+basepython =
+    python3
+deps =
+    mypy
+commands =
+    mypy knowit


### PR DESCRIPTION
Drop deprecated pytest-runner in favor of using pytest directly
Drop extras-require and add them to tox dependencies
Fix babelfish min version for Python >= 3.10
Add support for PEP-517 with pyproject.toml
Add setup.cfg installation with a setup.py shim for editable installs
Add mypy support for type-hints
Add mypy configuration to setup.cfg
Add flake8 configuration to setup.cfg
Add tox-travis to use tox during travis runs