### PR TITLE
Catch decimal.InvalidOperation

### DIFF
--- a/knowit/rules/audio.py
+++ b/knowit/rules/audio.py
@@ -1,5 +1,5 @@
 import typing
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from logging import NullHandler, getLogger
 
 from knowit.core import Rule
@@ -54,7 +54,7 @@ class AudioChannelsRule(Rule):
             for i in position.split('/'):
                 try:
                     c += Decimal(i)
-                except ValueError:
+                except (ValueError, InvalidOperation):
                     logger.debug('Invalid %s: %s', self.description, i)
                     pass
 


### PR DESCRIPTION
Fix for Issue #87

Catch decimal.InvalidOperation when using mediainfo. Channel positions can return a string like "3/2/2.1.?" and a Decimal cannot be created from "2.1.?"