### PR TITLE
Update general.py for matching both the B and T variants of 3-letter codes

### DIFF
--- a/knowit/properties/general.py
+++ b/knowit/properties/general.py
@@ -81,7 +81,11 @@ class Language(Property[babelfish.Language]):
         """Handle languages."""
         try:
             if len(value) == 3:
-                return babelfish.Language.fromalpha3b(value)
+                try:
+                    return babelfish.Language.fromalpha3b(value)
+                except babelfish.Error:
+                    # Try alpha3t if alpha3b fails
+                    return babelfish.Language.fromalpha3t(value)
 
             return babelfish.Language.fromietf(value)
         except (babelfish.Error, ValueError):


### PR DESCRIPTION
Fix for matching 3-letter language codes in both the alpha3b and alpha3t methods (as per ISO 639-3)

Specifically, for French, "fre" is being recognized, but "fra" is not (yields null). Babelfish has 2 methods for 3-letter codes, alpha3b and alpha3t (as per ISO 639-3 "B" and "T" values).

With this change, when resolving a 3-letter code, Knowit will first try babelfish's alpha3b, and if that fails, will then try alpha3t, and only if that also fails will resort to IETF