### PR TITLE
Remove pkg-resources dependency

### DIFF
--- a/knowit/__init__.py
+++ b/knowit/__init__.py
@@ -6,7 +6,6 @@ __version__ = metadata.version(__package__)
 __short_version__ = '.'.join(__version__.split('.')[:2])
 __author__ = metadata.metadata(__package__)['author']
 __license__ = metadata.metadata(__package__)['license']
-__url__ = metadata.metadata(__package__)['home_page']
 
 del metadata
 

--- a/knowit/config.py
+++ b/knowit/config.py
@@ -2,8 +2,12 @@ import os
 import typing
 from logging import NullHandler, getLogger
 
-from pkg_resources import resource_stream
 import yaml
+
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files  # type: ignore[assignment,no-redef,import-not-found]
 
 from knowit.serializer import get_yaml_loader
 
@@ -28,7 +32,8 @@ class Config:
     def build(cls, path: typing.Optional[typing.Union[str, os.PathLike]] = None) -> 'Config':
         """Build config instance."""
         loader = get_yaml_loader()
-        with resource_stream('knowit', 'defaults.yml') as stream:
+        config_file = files(__package__).joinpath('defaults.yml')
+        with config_file.open('rb') as stream:
             cfgs = [yaml.load(stream, Loader=loader)]
 
         if path:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -336,7 +336,7 @@ def assert_expected(expected, actual, options=None):
     for (key, expected, actual) in different:
         print('{0}: Expected {1} got {2}'.format(key, expected, actual), file=sys.stderr)
 
-    if different and options and options['debug_data']:
+    if different and options and options.get('debug_data'):
         print(f'Version: {version}')
         print(options['debug_data']())
 


### PR DESCRIPTION
Also fix two deprecation warnings:
- 'home_page' is not defined in `metadata`  (this warning pops up from the `trakit` dependency also)
- 'debug_data' key is not found in `options`

I would like to add `knowit` as a dependency for `subliminal`, this is needed for it to work with python 3.12.