### PR TITLE
Add loaded_provider function and allow re-initializing un-loaded providers

### DIFF
--- a/knowit/providers/enzyme.py
+++ b/knowit/providers/enzyme.py
@@ -101,6 +101,10 @@ class EnzymeProvider(Provider):
             }
         })
 
+    def loaded(self) -> bool:
+        """Loaded when enzyme is imported."""
+        return True
+
     def accepts(self, video_path):
         """Accept only MKV files."""
         return video_path.lower().endswith('.mkv')

--- a/knowit/providers/ffmpeg.py
+++ b/knowit/providers/ffmpeg.py
@@ -4,6 +4,7 @@ import logging
 import re
 from logging import NullHandler, getLogger
 from subprocess import check_output
+from typing import Any, Union
 
 from knowit import VIDEO_EXTENSIONS
 from knowit.core import Property
@@ -24,7 +25,9 @@ from knowit.properties import (
     YesNo,
 )
 from knowit.provider import (
+    Executor,
     MalformedFileError,
+    NotFoundExecutor,
     Provider,
 )
 from knowit.rules import (
@@ -60,7 +63,7 @@ To load FFmpeg (ffprobe) from a specific location, please define the location as
 '''
 
 
-class FFmpegExecutor:
+class FFmpegExecutor(Executor):
     """Executor that knows how to execute media info: using ctypes or cli."""
 
     version_re = re.compile(r'\bversion\s+(?P<version>[^\b\s]+)')
@@ -69,11 +72,6 @@ class FFmpegExecutor:
         'windows': ('__PATH__', ),
         'macos': ('__PATH__', ),
     }
-
-    def __init__(self, location, version):
-        """Initialize the object."""
-        self.location = location
-        self.version = version
 
     def extract_info(self, filename):
         """Extract media info."""
@@ -91,7 +89,7 @@ class FFmpegExecutor:
             return version
 
     @classmethod
-    def get_executor_instance(cls, suggested_path=None):
+    def get_executor_instance(cls, suggested_path=None) -> Union["FFmpegExecutor", NotFoundExecutor]:
         """Return executor instance."""
         os_family = detect_os()
         logger.debug('Detected os: %s', os_family)
@@ -99,6 +97,7 @@ class FFmpegExecutor:
             executor = exec_cls.create(os_family, suggested_path)
             if executor:
                 return executor
+        return NotFoundExecutor(suggested_path)
 
 
 class FFmpegCliExecutor(FFmpegExecutor):
@@ -209,16 +208,24 @@ class FFmpegProvider(Provider):
         })
         self.executor = FFmpegExecutor.get_executor_instance(suggested_path)
 
+    def loaded(self) -> bool:
+        """If library or executable was found."""
+        # if executor is None, print a warning and set to False to not repeat the warning
+        if isinstance(self.executor, NotFoundExecutor):
+            if not self.executor.warned:
+                logger.warning(WARN_MSG)
+                self.executor.warned = True
+        # check if loaded
+        return bool(self.executor)
+
     def accepts(self, video_path):
         """Accept any video when FFprobe is available."""
-        if self.executor is None:
-            logger.warning(WARN_MSG)
-            self.executor = False
+        return self.loaded() and video_path.lower().endswith(VIDEO_EXTENSIONS)
 
-        return self.executor and video_path.lower().endswith(VIDEO_EXTENSIONS)
-
-    def describe(self, video_path, context):
+    def describe(self, video_path, context) -> dict[str, Any]:
         """Return video metadata."""
+        if not self.loaded():
+            return {}
         data = self.executor.extract_info(video_path)
 
         def debug_data():


### PR DESCRIPTION
For `subliminal`, I need to know beforehand if the provider that was chosen is loaded or not. Therefore the `loaded_provider` function that returns a dict with value True/False if the provider was/was not loaded.

At the same time, the `initialize` function does nothing if the `available_providers` is already filled. However, if `initialize` is called with a new context, it would be nice to reload at least the unloaded providers.
I tried to write it as backward compatible as possible.