### PR TITLE
Modify yaml_implicit_resolvers only in subclass of yaml.Resolver

### DIFF
--- a/knowit/serializer.py
+++ b/knowit/serializer.py
@@ -77,17 +77,16 @@ def get_yaml_dumper(context):
 def get_yaml_loader(constructors=None):
     """Return a yaml loader that handles sequences as python lists."""
     constructors = constructors or {}
-    yaml_implicit_resolvers = dict(DefaultResolver.yaml_implicit_resolvers)
+    custom_yaml_implicit_resolvers = {
+        ch: [(tag, regexp) for tag, regexp in vs if not tag.endswith('float')]
+        for ch, vs in DefaultResolver.yaml_implicit_resolvers.items()
+    }
 
     class Resolver(DefaultResolver):
         """Custom YAML Resolver."""
+        yaml_implicit_resolvers = custom_yaml_implicit_resolvers
 
-    Resolver.yaml_implicit_resolvers.clear()
-    for ch, vs in yaml_implicit_resolvers.items():
-        Resolver.yaml_implicit_resolvers.setdefault(ch, []).extend(
-            (tag, regexp) for tag, regexp in vs
-            if not tag.endswith('float')
-        )
+
     Resolver.add_implicit_resolver(  # regex copied from yaml source
         '!decimal',
         re.compile(r'''^(?:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,0 +1,10 @@
+# Need to import knowit to check if it changes the default behavior of pyyaml
+import knowit
+import yaml
+
+
+def test_unchanged_pyyaml() -> None:
+    ret = yaml.safe_load('value: 0.5')
+    assert isinstance(ret, dict)
+    assert "value" in ret
+    assert ret["value"] == 0.5


### PR DESCRIPTION
See https://github.com/Diaoul/subliminal/issues/1302

This PR fixes an unintended side-effect, that importing `knowit` changes the behavior of the `pyyaml` module.
It's not clear why the original code was provoking this side-effect, though.